### PR TITLE
(chore): Fixed the problem where Regex would not accept  - and . symbols

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -70,13 +70,13 @@ function AuthContent({ router }: AuthContentProps) {
 
   const validatePassword = (value: string) => {
     const passwordRegex =
-      /^(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&\-_.])[A-Za-z\d@$!%*?&\-_\.]{8,}$/;
+      /^(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
     setPasswordError(
       passwordRegex.test(value)
         ? ''
         : 'Password must be at least 8 characters, include an uppercase letter, a number, and a special character.'
     );
-  };   
+  };
 
   const validateConfirmPassword = (value: string) => {
     setConfirmPasswordError(

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -70,13 +70,13 @@ function AuthContent({ router }: AuthContentProps) {
 
   const validatePassword = (value: string) => {
     const passwordRegex =
-      /^(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
+      /^(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&\-_.])[A-Za-z\d@$!%*?&\-_\.]{8,}$/;
     setPasswordError(
       passwordRegex.test(value)
         ? ''
         : 'Password must be at least 8 characters, include an uppercase letter, a number, and a special character.'
     );
-  };
+  };   
 
   const validateConfirmPassword = (value: string) => {
     setConfirmPasswordError(

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -70,13 +70,13 @@ function AuthContent({ router }: AuthContentProps) {
 
   const validatePassword = (value: string) => {
     const passwordRegex =
-      /^(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
+      /^(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&\-_.])[A-Za-z\d@$!%*?&\-_\.]{8,}$/;
     setPasswordError(
       passwordRegex.test(value)
         ? ''
         : 'Password must be at least 8 characters, include an uppercase letter, a number, and a special character.'
     );
-  };
+  };  
 
   const validateConfirmPassword = (value: string) => {
     setConfirmPasswordError(


### PR DESCRIPTION
In the pull-request i fixed the problem of the password field telling Password must be at least 8 characters, include an uppercase letter, a number, and a special character. when using a - or a . in the password like for example tEsT-Sc1bBl!e$ab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated password validation to allow additional special characters (hyphens, underscores, and periods) for enhanced user flexibility during authentication and registration.
  
- **Bug Fixes**
	- Minor formatting adjustment in the password validation function for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->